### PR TITLE
Fix gene2 coords bug

### DIFF
--- a/chlgene_fingerprintable.R
+++ b/chlgene_fingerprintable.R
@@ -48,7 +48,7 @@ extract_shortest_interval_between_genes <- function(gene1, gene2 = NULL, input_d
       }
       
       if (!is.null(gene2) && (gene_val == gene2 || grepl(gene2, product_val))) {
-        gene2_coords <- c(gene2_coords, coords_list)
+        gene2_coords <- c(gene2_coords, list(coords_list))
       }
     }
     


### PR DESCRIPTION
## Summary
- fix `gene2_coords` aggregation in `extract_shortest_interval_between_genes`

## Testing
- `Rscript -e "print('test')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f497ab1bc8322ac8b674a918321d8